### PR TITLE
Files were left in scratch_dir, auto-ident LICENSE

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 2, June 1991
 
- Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc., <http://fsf.org/>
  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
@@ -290,8 +290,8 @@ to attach them to the start of each source file to most effectively
 convey the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
+    {description}
+    Copyright (C) {year}  {fullname}
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -329,7 +329,7 @@ necessary.  Here is a sample; alter the names:
   Yoyodyne, Inc., hereby disclaims all copyright interest in the program
   `Gnomovision' (which makes passes at compilers) written by James Hacker.
 
-  <signature of Ty Coon>, 1 April 1989
+  {signature of Ty Coon}, 1 April 1989
   Ty Coon, President of Vice
 
 This General Public License does not permit incorporating your program into
@@ -337,4 +337,3 @@ proprietary programs.  If your program is a subroutine library, you may
 consider it more useful to permit linking proprietary applications with the
 library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.
-

--- a/README.rst
+++ b/README.rst
@@ -168,3 +168,8 @@ By default, XenonMKV tries not to resample, downmix or re-encode any part of the
 If the audio track in your MKV file is already AAC, the next thing to consider is your playback device. The Xbox 360 will not play audio in an MP4 container unless it is 2-channel stereo, which is a highly stupid limitation. Other devices, like the PlayBook, will happily parse up to 5.1 channel audio. By using either the `--channels` or `--profile` settings, you can tell XenonMKV how many channels of audio are acceptable from an AAC source before it will aggressively re-encode and downmix to 2-channel stereo.
 
 In short, if you plan to play MP4s on your Xbox 360, definitely use the `--profile xbox360` setting to make sure that no more than two channels make it into the output file. If your device is more reasonable, the default settings should be fine. More profiles will be added as users confirm their own device capabilities.
+
+
+.. image:: https://badges.gitter.im/xenonmkv/Lobby.svg
+   :alt: Join the chat at https://gitter.im/xenonmkv/Lobby
+   :target: https://gitter.im/xenonmkv/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge

--- a/xenonmkv/xenonmkv.py
+++ b/xenonmkv/xenonmkv.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 
 # XenonMKV: wrapper utility for MKV to MP4 container conversions
+# BenjaminHCCarr, bencarr@gmail.com
 # barisariburnu, barisariburnu@gmail.com
-# https://github.com/barisariburnu/xenonmkv
+# https://github.com/BenjaminHCCarr/xenonmkv
 
 import sys
 import os
 import ConfigParser
+import shutil
 
 
 def prompt_install_python27():
@@ -495,7 +497,9 @@ def main():
         log_exception("package", e)
 
     # Move the file to the destination directory with the original name
+    scratch_path = os.path.join(args.scratch_dir, source_noext + ".mp4")
     dest_path = os.path.join(args.destination, source_noext + ".mp4")
+    shutil.move(scratch_path, dest_path)
 
     log.info("Processing of {0} complete; file saved as {1}".format(
              args.source_file, dest_path))

--- a/xenonmkv/xenonmkv.py
+++ b/xenonmkv/xenonmkv.py
@@ -392,7 +392,7 @@ def main():
 
     source_basename = os.path.basename(args.source_file)
     log.debug("Source Basename: {0}".format(source_basename))
-    source_noext = source_basename
+    source_noext = os.path.splitext(source_basename)[0]
 
     if not args.name:
         args.name = source_noext


### PR DESCRIPTION
`0.4.3` left the code in the `scratch_dir`; this code changes that.
By changing the license file name, github auto identifies it as GPL2